### PR TITLE
Add projection feature

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,8 +25,10 @@
   "rules": {
     "semi": "error",
     "no-tabs": "off",
-    "indent": "off",
-    "no-underscore-dangle": "off"
+    "indent": "error",
+    "no-underscore-dangle": "off",
+    "no-trailing-spaces": "error",
+    "comma-spacing": "error"
   },
   "overrides": [
     {

--- a/README.md
+++ b/README.md
@@ -17,9 +17,25 @@ console.log(leblad.getWilayaList());
 
 #### API
 
-##### getWilayaList()
+##### getWilayaList(projection?: string[])
 
 Returns a list of Algerian provinces (Wilayas)
+
+**Arguments**
+
+`projection: string[]` (optional) Array of Wilaya Object attributes.
+
+**Examples**
+
+```javascript
+const { getWilayaList } = require('leblad');
+
+const allWilayasDetails = getWilayaList();
+
+// if we only want the wilaya names for example:
+const wilayasNames = getWilayaList(['name', 'name_ar', 'name_en']);
+
+```
 
 ### Local development
 

--- a/src/api/getWilayaList.js
+++ b/src/api/getWilayaList.js
@@ -1,3 +1,5 @@
-const getWilayaList = data => () => data;
+const projectWilaya = require('../utils/projections/wilayaProjection');
+
+const getWilayaList = data => (projection) =>  projectWilaya(data, projection);
 
 module.exports = getWilayaList;

--- a/src/utils/projections/wilayaProjection.js
+++ b/src/utils/projections/wilayaProjection.js
@@ -1,0 +1,24 @@
+const _projectWilayaObject = (wilayaObject, attributes) => {
+  return attributes.reduce((acc, attr)=> {
+    return {...acc, [attr]: wilayaObject[attr]};
+  }, {});
+};
+
+/**
+ * @param {Object|Array} data Wilaya data, it could be either a Wilaya object or a list of wilaya Objects
+ * @param {String[]} projection a list of attributes to keep
+ *
+ */
+const projectWilaya = (wilayaData, projection) => {
+  if (!projection) {
+    return wilayaData;
+  }
+
+  if (Array.isArray(wilayaData)) {
+    return wilayaData.map(w => _projectWilayaObject(w, projection));
+  }
+
+  return _projectWilayaObject(wilayaData, projection);
+};
+
+module.exports = projectWilaya;

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -2,11 +2,11 @@
  * @type {import('@stryker-mutator/api/core').StrykerOptions}
  */
 module.exports = {
-	mutator: 'javascript',
-	packageManager: 'npm',
-	reporters: ['html', 'clear-text', 'progress', 'dashboard'],
-	testRunner: 'jest',
-	transpilers: [],
+  mutator: { name: 'javascript', excludedMutations: ['StringLiteral'] },
+  packageManager: 'npm',
+  reporters: ['html', 'clear-text', 'progress', 'dashboard'],
+  testRunner: 'jest',
+  transpilers: [],
   coverageAnalysis: 'off',
   files: [
     'src/**/*.js',

--- a/tests/api/getWilayaList.test.js
+++ b/tests/api/getWilayaList.test.js
@@ -1,4 +1,3 @@
- 
 describe('get the full Wilaya list', () => {
   let getWilayaList;
 

--- a/tests/utils/projections/wilayaListProjection.test.js
+++ b/tests/utils/projections/wilayaListProjection.test.js
@@ -1,0 +1,34 @@
+describe('Wilaya list projection', ()=> {
+  const mockDataArray = [{food: 'mhajeb', drink: 'lben', isBnin: true}, {food: 'zviti', drink: 'rayeb', isBnin: true}];
+  const mockDataObject = {food: 'karentika', drink: 'RedBull', isBnin: true};
+
+  let projectWilaya;
+
+  beforeEach(()=> {
+    projectWilaya = require('../../../src/utils/projections/wilayaProjection');
+  });
+
+  describe('if no projection parameter is passed', ()=> {
+    it.each([
+      ['array', mockDataArray],
+      ['object', mockDataObject]
+    ])('should return the "same" data %s as it is if no parameters were passed', (type, data)=> {
+      expect(projectWilaya(data)).toEqual(data);
+    });
+  });
+
+  describe('when passing the projection parameter', ()=> {
+    const projection = ['food', 'isBnin'];
+
+    it('should return the data array with only the desired attributes', ()=> {
+      expect(projectWilaya(mockDataArray, projection)).toEqual([
+        {food: 'mhajeb', isBnin: true},
+        {food: 'zviti',  isBnin: true}
+      ]);
+    });
+
+    it('should return the data object with only the desired attributes', ()=> {
+      expect(projectWilaya(mockDataObject, projection)).toEqual({food: 'karentika', isBnin: true});
+    });
+  });
+});


### PR DESCRIPTION
# Description

Added a feature to project `wilaya` data. Also, I made some small changes to eslint and stryker config.

## Why
Responses can be unnecessarily very long, so I thought that it make sense to project the results and only return what we need.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I checked that there's no dataset update (can be done by running `npm run update-dataset`)
- [x] `npm test` passes on my machine
- [x] `npm run lint` passes on my machine