### PR TITLE
feat: add getAdjacentWilayas

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ const wilayasNames = getWilayaList(['name', 'name_ar', 'name_en']);
 
 ```
 
+##### getAdjacentWilayas(wilayaCode?: number)
+
+Takes a wilaya code (matricule) and returns a list of adjacent wilayas codes
+
+**Arguments**
+
+`wilayaCode: number` (**required**) the Wilaya's "matricule"
+
+**Examples**
+
+```javascript
+const { getAdjacentWilayas } = require('leblad');
+
+console.log(getAdjacentWilayas(31)); // will print [46, 22, 29, 27]
+```
 ### Local development
 
 #### Perquisites

--- a/src/api/getAdjacentWilayas.js
+++ b/src/api/getAdjacentWilayas.js
@@ -1,0 +1,20 @@
+
+const getAdjacentWilayas = data =>
+/**
+ * Takes a wilaya code (matricule) and returns a list of adjacent wilayas codes
+ *
+ * @example <p> Get Oran's adjacent wilayas
+ * //returns [46, 22, 29, 27]
+ * getAdjacentWilayas(31)
+ *
+ * @param { Number} wilayaCode The Wilaya's "matricule"
+ * @returns { Number[] | undefined } Returns adjacent wilayas codes, or undefined
+ */
+  (wilayaCode) =>  {
+    const { adjacentWilayas } = data.find(w => w.mattricule === wilayaCode) || {};
+
+    return adjacentWilayas;
+
+  };
+
+module.exports = getAdjacentWilayas;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const getWilayaList = require('./api/getWilayaList');
+const getAdjacentWilayas = require('./api/getAdjacentWilayas');
 
 const data = require('../data/WilayaList.json');
 
@@ -6,5 +7,6 @@ const _getData = () => ([...data]);
 
 
 module.exports = {
-  getWilayaList: getWilayaList(_getData())
+  getWilayaList: getWilayaList(_getData()),
+  getAdjacentWilayas: getAdjacentWilayas(_getData())
 };

--- a/tests/api/getAdjacentWilayas.test.js
+++ b/tests/api/getAdjacentWilayas.test.js
@@ -1,0 +1,45 @@
+describe('get adjacent wilayas', ()=> {
+  const mockData = [{
+    mattricule: 1,
+    name: "Adrar",
+    adjacentWilayas: [37, 8, 32, 3, 47, 11]
+  },
+  {
+    mattricule: 2,
+    name: "Chlef",
+    adjacentWilayas: [27, 48, 7, 38, 44, 42]
+  },
+  {
+    mattricule: 3,
+    name: "Laghouat",
+    adjacentWilayas: [32, 47, 17, 14]
+  }];
+
+  let getAdjacentWilayas;
+
+  beforeEach(()=> {
+    getAdjacentWilayas = require('../../src/api/getAdjacentWilayas');
+  });
+
+  it('should export a function', () => {
+    expect(typeof getAdjacentWilayas).toBe('function');
+  });
+
+  it('should return return a curried function that returns the data', () => {
+    const fn = getAdjacentWilayas(mockData);
+
+    expect(typeof fn).toBe('function');
+  });
+
+  it('should return undefined if the wilaya with the given code is not found', () => {
+    const result = getAdjacentWilayas(mockData)(31);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return adjacent wilayas array', () => {
+    const result = getAdjacentWilayas(mockData)(2);
+
+    expect(result).toEqual([27, 48, 7, 38, 44, 42]);
+  });
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,11 +1,20 @@
 describe("Le'Bled SDK", () => {
   let data;
+  let lbledSdk;
 
   beforeEach(()=> {
-    data  =require('../data/WilayaList.json');
+    data = require('../data/WilayaList.json');
+    lbledSdk = require('../src/index');
   });
 
   it('data should be present', () => {
     expect( data).toHaveLength(48);
+  });
+
+  it('should export API functions', () => {
+    expect(lbledSdk).toMatchObject({
+      getWilayaList: expect.any(Function),
+      getAdjacentWilayas: expect.any(Function),
+    });
   });
 });


### PR DESCRIPTION
# Description

Add `getAdjacentWilayas` method that returns a list of adjacent wilayas.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I checked that there's no dataset update (can be done by running `npm run update-dataset`)
- [x] `npm test` passes on my machine
- [x] `npm run lint` passes on my machine