### PR TITLE
:sparkles: add getWilayaByCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Takes a wilaya code (matricule) and returns the matching wilaya
 
 ```javascript
 const { getWilayaByCode } = require('leblad');
-console.log(getWilayaByCode(31)); // will print {name: "Oran"...}
+console.log(getWilayaByCode(31)); // will the wilaya object ({name: "Oran"...})
 ```
 
 ### Local development

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ const wilayasNames = getWilayaList(['name', 'name_ar', 'name_en']);
 
 ```
 
+##### getWilayaByCode(wilayaCode?: number)
+
+Takes a wilaya code (matricule) and returns the matching wilaya
+
+**Arguments**
+
+`wilayaCode: number` (**required**) the Wilaya's "matricule"
+
+**Examples**
+
+```javascript
+const { getWilayaByCode } = require('leblad');
+console.log(getWilayaByCode(31)); // will print {name: "Oran"...}
+```
+
 ### Local development
 
 #### Perquisites

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const wilaya = getWilayaByZipCode(1000);
 const wilayaAttributes = getWilayaByZipCode(1000, ['name', 'mattricule']);
 ```
 
-##### getWilayaByCode(wilayaCode?: number)
+##### getWilayaByCode(wilayaCode: number, projection?: string[])
 
 Takes a wilaya code (matricule) and returns the matching wilaya
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "leblad-sdk",
-  "version": "1.0.0",
+  "name": "leblad",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/api/getWilayaByCode.js
+++ b/src/api/getWilayaByCode.js
@@ -1,0 +1,19 @@
+const projectWilaya = require('../utils/projections/wilayaProjection');
+
+const getWilayaByCode = data =>
+/**
+ * Takes a wilaya code (matricule) and returns its respective wilaya
+ *
+ * @example <p> Get Oran wilaya
+ * //returns ["Oran"]
+ * getWilayaByCode(31)
+ *
+ * @param { Number} mattricule The Wilaya's "matricule"
+ * @returns { Number[] | undefined } Returns matching wilaya, or undefined
+ */
+  (mattricule, projection) =>  {
+    const wilaya = data.find(w => w.mattricule === mattricule);
+    return projectWilaya(wilaya, projection);
+  };
+
+module.exports = getWilayaByCode;

--- a/src/api/getWilayaByCode.js
+++ b/src/api/getWilayaByCode.js
@@ -9,6 +9,7 @@ const getWilayaByCode = data =>
  * getWilayaByCode(31)
  *
  * @param { Number} mattricule The Wilaya's "matricule"
+ * @param {String[]} projection a list of  wilaya object attributes to keep
  * @returns { Object | undefined } Returns matching wilaya, or undefined
  */
   (mattricule, projection) =>  {

--- a/src/api/getWilayaByCode.js
+++ b/src/api/getWilayaByCode.js
@@ -9,7 +9,7 @@ const getWilayaByCode = data =>
  * getWilayaByCode(31)
  *
  * @param { Number} mattricule The Wilaya's "matricule"
- * @returns { Number[] | undefined } Returns matching wilaya, or undefined
+ * @returns { Object | undefined } Returns matching wilaya, or undefined
  */
   (mattricule, projection) =>  {
     const wilaya = data.find(w => w.mattricule === mattricule);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const getWilayaList = require('./api/getWilayaList');
+const getWilayaByCode = require('./api/getWilayaByCode');
 
 const data = require('../data/WilayaList.json');
 
@@ -6,5 +7,6 @@ const _getData = () => ([...data]);
 
 
 module.exports = {
-  getWilayaList: getWilayaList(_getData())
+  getWilayaList: getWilayaList(_getData()),
+  getWilayaByCode: getWilayaByCode(_getData()),
 };

--- a/tests/api/getWilayaByCode.test.js
+++ b/tests/api/getWilayaByCode.test.js
@@ -1,0 +1,45 @@
+describe('get matching wilaya', ()=> {
+  const mockData = [{
+    mattricule: 1,
+    name: "Adrar"
+  },
+  {
+    mattricule: 2,
+    name: "Chlef"
+  },
+  {
+    mattricule: 3,
+    name: "Laghouat"
+  }];
+
+  let getWilayaByCode;
+
+  beforeEach(()=> {
+    getWilayaByCode = require('../../src/api/getWilayaByCode');
+  });
+
+  it('should export a function', () => {
+    expect(typeof getWilayaByCode).toBe('function');
+  });
+
+  it('should return a curried function that returns the data', () => {
+    const fn = getWilayaByCode(mockData);
+
+    expect(typeof fn).toBe('function');
+  });
+
+  it('should return undefined if the wilaya with the given mattricule is not found', () => {
+    const result = getWilayaByCode(mockData)(31);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return matching wilaya array', () => {
+    const result = getWilayaByCode(mockData)(2);
+
+    expect(result).toEqual({
+      mattricule: 2,
+      name: "Chlef"
+    });
+  });
+});


### PR DESCRIPTION
# Description

Add `getWilayaByCode` method that gets a wilaya code as a parameter and returns the matching wilaya.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Updated the dataset

# Checklist:

- [x] I checked that there's no dataset update (can be done by running `npm run update-dataset`)
- [x] `npm test` passes on my machine
- [x] `npm run lint` passes on my machine