### PR TITLE
feat: Add getWilayaByZipCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,19 @@ Returns a list of Algerian provinces (Wilayas)
 **Examples**
 
 ```javascript
-const { getWilayaList } = require('leblad');
+const { getWilayaList, getWilayaByZipCode } = require('leblad');
 
 const allWilayasDetails = getWilayaList();
 
 // if we only want the wilaya names for example:
 const wilayasNames = getWilayaList(['name', 'name_ar', 'name_en']);
 
+// To get the wilaya that includes the zip code 1000, We can use getWilayaByZipCode
+// This example will return Adrar { name: "Adrar", ...}
+const wilaya = getWilayaByZipCode(1000);
+
+// We can also select only attributes that we want, For example select name and mattricule:
+const wilayaAttributes = getWilayaByZipCode(1000, ['name', 'mattricule']);
 ```
 
 ### Local development

--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ console.log(leblad.getWilayaList());
 
 Returns a list of Algerian provinces (Wilayas)
 
+##### getWilayaByZipCode(zipCode: number, projection?: string[])
+
+Returns a wilaya that includes the given zipCode.
+
 **Arguments**
 
 `projection: string[]` (optional) Array of Wilaya Object attributes.
+
+`zipCode: number` (required) A zip code.
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ console.log(leblad.getWilayaList());
 
 Returns a list of Algerian provinces (Wilayas)
 
+**Arguments**
+
+`projection: string[]` (optional) Array of Wilaya Object attributes.
+
 ##### getWilayaByZipCode(zipCode: number, projection?: string[])
 
 Returns a wilaya that includes the given zipCode.
@@ -28,7 +32,6 @@ Returns a wilaya that includes the given zipCode.
 **Arguments**
 
 `projection: string[]` (optional) Array of Wilaya Object attributes.
-
 `zipCode: number` (required) A zip code.
 
 **Examples**

--- a/src/api/getWilayaByZipCode.js
+++ b/src/api/getWilayaByZipCode.js
@@ -1,14 +1,16 @@
 const getWilayaByZipCode = data =>
-  /**
+/**
    * Takes a zip code (postal code) and returns it's wilaya.
    *
    * @example <p> Get 1000 wilaya
-   * //returns {mattricule: '1', name: 'Adrar', ...} because the zip code 1000 belongs to Adrar 
+   *
+   * //returns {mattricule: '1', name: 'Adrar', ...} because the zip code 1000 belongs to Adrar
    * getWilayaByZipCode(31)
    *
    * @param { Number } zipCode postal code
    * @returns { Object | undefined } Returns the target object, or undefined
    */
+
   (zipCode) => data.find(w => w.postalCodes.includes(zipCode));
 
 module.exports = getWilayaByZipCode;

--- a/src/api/getWilayaByZipCode.js
+++ b/src/api/getWilayaByZipCode.js
@@ -1,0 +1,14 @@
+const getWilayaByZipCode = data =>
+  /**
+   * Takes a zip code (postal code) and returns it's wilaya.
+   *
+   * @example <p> Get 1000 wilaya
+   * //returns {mattricule: '1', name: 'Adrar', ...} because the zip code 1000 belongs to Adrar 
+   * getWilayaByZipCode(31)
+   *
+   * @param { Number } zipCode postal code
+   * @returns { Object | undefined } Returns the target object, or undefined
+   */
+  (zipCode) => data.find(w => w.postalCodes.includes(zipCode));
+
+module.exports = getWilayaByZipCode;

--- a/src/api/getWilayaByZipCode.js
+++ b/src/api/getWilayaByZipCode.js
@@ -1,3 +1,5 @@
+const projectWilaya = require('../utils/projections/wilayaProjection');
+
 const getWilayaByZipCode = data =>
 /**
    * Takes a zip code (postal code) and returns it's wilaya.
@@ -11,6 +13,9 @@ const getWilayaByZipCode = data =>
    * @returns { Object | undefined } Returns the target object, or undefined
    */
 
-  (zipCode) => data.find(w => w.postalCodes.includes(zipCode));
+  (zipCode, projection) => {
+    const wilaya = data.find(w => w.postalCodes.includes(zipCode));
+    return projectWilaya(wilaya, projection);
+  };
 
 module.exports = getWilayaByZipCode;

--- a/src/api/getWilayaByZipCode.js
+++ b/src/api/getWilayaByZipCode.js
@@ -10,6 +10,7 @@ const getWilayaByZipCode = data =>
    * getWilayaByZipCode(31)
    *
    * @param { Number } zipCode postal code
+   * @param {String[]} projection a list of  wilaya object attributes to keep
    * @returns { Object | undefined } Returns the target object, or undefined
    */
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const getWilayaList = require('./api/getWilayaList');
+const getWilayaByZipCode = require('./api/getWilayaByZipCode');
 
 const data = require('../data/WilayaList.json');
 
@@ -6,5 +7,6 @@ const _getData = () => ([...data]);
 
 
 module.exports = {
-  getWilayaList: getWilayaList(_getData())
+  getWilayaList: getWilayaList(_getData()),
+  getWilayaByZipCode: getWilayaByZipCode(_getData()),
 };

--- a/tests/api/getWilayaByZipCode.test.js
+++ b/tests/api/getWilayaByZipCode.test.js
@@ -25,7 +25,7 @@ describe('get wilaya by zip code', () => {
 
   beforeEach(() => {
     getWilayaByZipCode = require('../../src/api/getWilayaByZipCode');
-  })
+  });
 
   it('should return return a curried function that returns the data', () => {
     const fn = getWilayaByZipCode(mockData);

--- a/tests/api/getWilayaByZipCode.test.js
+++ b/tests/api/getWilayaByZipCode.test.js
@@ -1,0 +1,52 @@
+describe('get wilaya by zip code', () => {
+  const mockData = [{
+    mattricule: 1,
+    name: "Adrar",
+    postalCodes: [
+      1000,
+      1001,
+      1002,
+      1003,
+      1004,
+    ]
+  }, {
+    mattricule: 2,
+    name: "Chlef",
+    postalCodes: [
+      2008,
+      2009,
+      2010,
+      2011,
+      2012,
+    ]
+  }];
+
+  let getWilayaByZipCode;
+
+  beforeEach(() => {
+    getWilayaByZipCode = require('../../src/api/getWilayaByZipCode');
+  })
+
+  it('should return return a curried function that returns the data', () => {
+    const fn = getWilayaByZipCode(mockData);
+
+    expect(typeof fn).toBe('function');
+  });
+
+  it('should return the target wialaya object', () => {
+    let result = getWilayaByZipCode(mockData)(2009);
+    expect(result.mattricule).toEqual(2);
+
+    result = getWilayaByZipCode(mockData)(2012);
+    expect(result.mattricule).toEqual(2);
+
+    result = getWilayaByZipCode(mockData)(2008);
+    expect(result.mattricule).toEqual(2);
+  });
+
+  it('should return undefined if the zip code doesn\'t exists', () => {
+    const result = getWilayaByZipCode(mockData)(99999);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/update-wilaya-dataset.js
+++ b/update-wilaya-dataset.js
@@ -39,7 +39,7 @@ const VERSION_FILE_PATH = `${DATA_DIRECTORY}/VERSION`;
     await writeFileAsync(VERSION_FILE_PATH, tagName);
     console.log(`  > Updated local version file`);
 
-    console.warn(`\nPlease check "${tagURL}" to double-check if there's any breaking changes before commiting this`);
+    console.warn(`\nPlease check "${tagURL}" to double-check if there's any breaking changes before committing this`);
   }
 })();
 


### PR DESCRIPTION
# Description

Add `getWilayaByZipCode ` method that gets a wilaya that the given zip code belongs to.


## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


# Checklist:

- [x] I checked that there's no dataset update (can be done by running `npm run update-dataset`)
- [x] `npm test` passes on my machine
- [x] `npm run lint` passes on my machine