### PR TITLE
feat: add getPhoneCodeForWilaya

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,22 @@ const { getPhoneCodesForWilaya } = require('@dzcode-io/leblad');
 console.log(getPhoneCodesForWilaya(31)); //returns list of phone codes for wilaya 31
 ```
 
+#### getPhoneCodeForWilaya(wilayaCode: number)
+
+Takes a wilaya code (matricule) and returns the first phone code from a list of phone codes for given wilaya
+
+**Arguments**
+
+- `wilayaCode: number` (**required**) the Wilaya's "matricule"
+
+**Examples**
+
+```javascript
+const { getPhoneCodeForWilaya } = require('@dzcode-io/leblad');
+
+console.log(getPhoneCodeForWilaya(16)); //returns first phone code for wilaya 16
+```
+
 ## Helper methods
 
 #### wilayaProjection(wilaya: (object|array), projection?: string[])

--- a/src/api/getPhoneCodeForWilaya.js
+++ b/src/api/getPhoneCodeForWilaya.js
@@ -1,0 +1,21 @@
+const getPhoneCodesForWilaya = require('./getPhoneCodesForWilaya');
+
+const getPhoneCodeForWilaya = data =>
+/**
+   * Takes a wilaya code (mattricule) and returns the first phone code in wilaya's phone code list.
+   *
+   * @example Get phone codes for Alger (code: 16)
+   *
+   * //returns 21
+   * getPhoneCodeForWilaya(16)
+   *
+   * @param { Number } wilayaCode wilaya code (mattricule)
+   * @returns { Number | Undefined } Returns the first phone code for wilaya, or undefined
+   */
+
+  (wilayaCode) => {
+    const phoneCodes = getPhoneCodesForWilaya(data)(wilayaCode) || [];
+    return phoneCodes[0];
+  };
+
+module.exports = getPhoneCodeForWilaya;

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const getWilayaByZipCode = require('./api/getWilayaByZipCode');
 const getZipCodesForWilaya = require('./api/getZipCodesForWilaya');
 const getDairatsForWilaya = require('./api/getDairatsForWilaya');
 const getPhoneCodesForWilaya = require('./api/getPhoneCodesForWilaya');
+const getPhoneCodeForWilaya = require('./api/getPhoneCodeForWilaya');
 
 const data = require('../data/WilayaList.json');
 
@@ -23,6 +24,7 @@ module.exports = {
   getZipCodesForWilaya: getZipCodesForWilaya(_getData()),
   getDairatsForWilaya: getDairatsForWilaya(_getData()),
   getPhoneCodesForWilaya: getPhoneCodesForWilaya(_getData()),
+  getPhoneCodeForWilaya: getPhoneCodeForWilaya(_getData()),
   utils: {
     wilayaProjection,
     isValidWilayaCode,

--- a/tests/api/getPhoneCodeForWilaya.test.js
+++ b/tests/api/getPhoneCodeForWilaya.test.js
@@ -1,0 +1,51 @@
+describe('get phone codes for a wilaya', ()=> {
+  const mockData = [{
+    mattricule: 16,
+    name: "Alger",
+    phoneCodes: [21, 23]
+  },
+  {
+    mattricule: 31,
+    name: "Oran",
+    phoneCodes: [41]
+  },
+  {
+    mattricule: 48,
+    name: "Relizane",
+    phoneCodes: [46],
+  }];
+
+  let getPhoneCodeForWilaya;
+
+  beforeEach(()=> {
+    getPhoneCodeForWilaya = require('../../src/api/getPhoneCodeForWilaya');
+  });
+
+  it('should export a function', () => {
+    expect(typeof getPhoneCodeForWilaya).toBe('function');
+  });
+
+  it('should return a curried function that returns the data', () => {
+    const fn = getPhoneCodeForWilaya(mockData);
+
+    expect(typeof fn).toBe('function');
+  });
+
+  it('should return undefined if the phone codes for the given wilaya code could not be found', () => {
+    const result = getPhoneCodeForWilaya(mockData)(9);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the correct phone code for a given wilaya', () => {
+    const result = getPhoneCodeForWilaya(mockData)(31);
+
+    expect(result).toEqual(41);
+  });
+
+  it('should return the first phone code in an array of multiple phone codes for a given wilaya', () => {
+    const result = getPhoneCodeForWilaya(mockData)(16);
+
+    expect(result).toEqual(21);
+  });
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -20,6 +20,7 @@ describe("Le'Bled SDK", () => {
       getWilayaByZipCode: expect.any(Function),
       getDairatsForWilaya: expect.any(Function),
       getPhoneCodesForWilaya: expect.any(Function),
+      getPhoneCodeForWilaya: expect.any(Function),
       utils: {
         wilayaProjection: expect.any(Function),
         isValidZipCode: expect.any(Function),


### PR DESCRIPTION
# Description

- Added getPhoneCodeForWilaya method that returns the first phone code from a list of phone codes
for a given wilaya
- Added tests for getPhoneCodeForWilaya
- Exported method in index.js
- Updated test for index.js
- Added method to documentation in README

Closes #19

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I checked that there's no dataset update (can be done by running `npm run update-dataset`)
- [x] `npm test` passes on my machine
- [x] `npm run lint` passes on my machine