### PR TITLE
Refactor: return null instead of undefined

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,14 @@ module.exports = {
   clearMocks: true,
   collectCoverage: true,
   coverageDirectory: 'coverage',
-  // coverageThreshold: undefined,
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100
+    }
+  },
   resetMocks: true,
   resetModules: true,
   testEnvironment: 'node',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dzcode-io/leblad",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dzcode-io/leblad",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Algerian administrative areas package",
   "main": "src/index.js",
   "private": false,

--- a/src/api/getAdjacentWilayas.js
+++ b/src/api/getAdjacentWilayas.js
@@ -8,12 +8,12 @@ const getAdjacentWilayas = data =>
  * getAdjacentWilayas(31)
  *
  * @param { Number} wilayaCode The Wilaya's "matricule"
- * @returns { Number[] | undefined } Returns adjacent wilayas codes, or undefined
+ * @returns { Number[] | null } Returns adjacent wilayas codes, or null
  */
   (wilayaCode) =>  {
     const { adjacentWilayas } = data.find(w => w.mattricule === wilayaCode) || {};
 
-    return adjacentWilayas;
+    return adjacentWilayas || null;
 
   };
 

--- a/src/api/getDairatsForWilaya.js
+++ b/src/api/getDairatsForWilaya.js
@@ -9,7 +9,7 @@ const getDairatsForWilaya = data =>
  *
  * @param { Number} mattricule The Wilaya's "matricule"
  * @param {String[]} projection a list of daira object attributes to keep
- * @returns { object[] | undefined } Returns All dairats for wilaya, or undefined
+ * @returns { object[] | null } Returns All dairats for wilaya, or null
  */
 
   (mattricule, projection) => {

--- a/src/api/getPhoneCodeForWilaya.js
+++ b/src/api/getPhoneCodeForWilaya.js
@@ -10,12 +10,12 @@ const getPhoneCodeForWilaya = data =>
    * getPhoneCodeForWilaya(16)
    *
    * @param { Number } wilayaCode wilaya code (mattricule)
-   * @returns { Number | Undefined } Returns the first phone code for wilaya, or undefined
+   * @returns { Number | null } Returns the first phone code for wilaya, or null
    */
 
   (wilayaCode) => {
     const phoneCodes = getPhoneCodesForWilaya(data)(wilayaCode) || [];
-    return phoneCodes[0];
+    return phoneCodes[0] || null;
   };
 
 module.exports = getPhoneCodeForWilaya;

--- a/src/api/getPhoneCodesForWilaya.js
+++ b/src/api/getPhoneCodesForWilaya.js
@@ -8,12 +8,12 @@ const getPhoneCodesForWilaya = data =>
    * getPhoneCodesForWilaya(16)
    *
    * @param { Number } wilayaCode wilaya code (mattricule)
-   * @returns { Number[] | Undefined } Returns wilaya's phone codes, or undefined
+   * @returns { Number[] | null } Returns wilaya's phone codes, or null
    */
 
   (wilayaCode) => {
     const { phoneCodes } = data.find((w) => w.mattricule === wilayaCode) || {};
-    return phoneCodes;
+    return phoneCodes || null;
   };
 
 module.exports = getPhoneCodesForWilaya;

--- a/src/api/getWilayaByCode.js
+++ b/src/api/getWilayaByCode.js
@@ -10,7 +10,7 @@ const getWilayaByCode = data =>
  *
  * @param { Number} mattricule The Wilaya's "matricule"
  * @param {String[]} projection a list of  wilaya object attributes to keep
- * @returns { Object | undefined } Returns matching wilaya, or undefined
+ * @returns { Object | null } Returns matching wilaya, or null
  */
   (mattricule, projection) =>  {
     const wilaya = data.find(w => w.mattricule === mattricule);

--- a/src/api/getWilayaByDairaName.js
+++ b/src/api/getWilayaByDairaName.js
@@ -12,11 +12,11 @@ const getWilayaByDairaName = data =>
  *
  * @param { String } daira The Wilaya's daira name(en | ar | fr)
  * @param {String[]} projection a list of  wilaya object attributes to keep
- * @returns { Object | undefined } Returns matching wilaya, or undefined
+ * @returns { Object | null } Returns matching wilaya, or null
  */
   (daira, projection) =>  {
     if (!daira || daira.trim().length < MIN_DAIRA_LENGTH) {
-      return;
+      return null;
     }
 
     const dairaName = daira.toLowerCase();
@@ -29,7 +29,6 @@ const getWilayaByDairaName = data =>
       )
     );
 
-    // eslint-disable-next-line consistent-return
     return projectWilaya(wilaya, projection);
   };
 

--- a/src/api/getWilayaByPhoneCode.js
+++ b/src/api/getWilayaByPhoneCode.js
@@ -11,7 +11,7 @@ const getWilayaByPhoneCode = data =>
 *
 * @param { Number | String } phoneCode is a number if the latter corresponds to the wilaya's phone code and a string if's the full phone number
 * @param {String[]} projection a list of wilaya object attributes to keep
-* @returns { Object | undefined } Returns the target object, or undefined
+* @returns { Object | null } Returns the target object, or null
 */
   (phoneCode, projection) => {
     const phoneCodeVar =  typeof phoneCode === "number"

--- a/src/api/getWilayaByZipCode.js
+++ b/src/api/getWilayaByZipCode.js
@@ -11,7 +11,7 @@ const getWilayaByZipCode = data =>
    *
    * @param { Number } zipCode postal code
    * @param {String[]} projection a list of  wilaya object attributes to keep
-   * @returns { Object | undefined } Returns the target object, or undefined
+   * @returns { Object | null } Returns the target object, or null
    */
 
   (zipCode, projection) => {

--- a/src/api/getZipCodesForWilaya.js
+++ b/src/api/getZipCodesForWilaya.js
@@ -8,12 +8,12 @@ const getZipCodesForWilaya = (data) =>
   * //returns Array containing Zip-codes for respective wilaya
   *
   * @param { Number} wilayaCode The Wilaya's "matricule"
-  * @returns { Number[] | undefined } Returns Zip-codes for wilaya, or undefined
+  * @returns { Number[] | null } Returns Zip-codes for wilaya, or null
   */
 
   (wilayaCode) => {
     const { postalCodes } = data.find((w) => w.mattricule === wilayaCode) || {};
-    return postalCodes;
+    return postalCodes || null;
   };
 
 module.exports = getZipCodesForWilaya;

--- a/src/utils/projections/wilayaProjection.js
+++ b/src/utils/projections/wilayaProjection.js
@@ -14,7 +14,7 @@ const _projectWilayaObject = (wilayaObject, attributes) => {
  */
 const projectWilaya = (wilayaData, projection) => {
   if (!wilayaData || !projection) {
-    return wilayaData;
+    return wilayaData || null;
   }
 
   if (Array.isArray(wilayaData)) {

--- a/tests/api/getAdjacentWilayas.test.js
+++ b/tests/api/getAdjacentWilayas.test.js
@@ -31,10 +31,10 @@ describe('get adjacent wilayas', ()=> {
     expect(typeof fn).toBe('function');
   });
 
-  it('should return undefined if the wilaya with the given code is not found', () => {
+  it('should return null if the wilaya with the given code is not found', () => {
     const result = getAdjacentWilayas(mockData)(31);
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 
   it('should return adjacent wilayas array', () => {

--- a/tests/api/getDairatsForWilaya.test.js
+++ b/tests/api/getDairatsForWilaya.test.js
@@ -112,8 +112,8 @@ describe('Get dairats for a wilaya', ()=>{
     expect(typeof getDairatsForWilaya(mockData)).toBe('function');
   });
 
-  it('should return undefined if the wilaya with the given code is not found', () => {
-    expect(getDairatsForWilaya(mockData)(289)).toBeUndefined();
+  it('should return null if the wilaya with the given code is not found', () => {
+    expect(getDairatsForWilaya(mockData)(289)).toBeNull();
   });
 
   it('should return dairats for given wilaya', ()=>{

--- a/tests/api/getPhoneCodeForWilaya.test.js
+++ b/tests/api/getPhoneCodeForWilaya.test.js
@@ -31,10 +31,10 @@ describe('get phone codes for a wilaya', ()=> {
     expect(typeof fn).toBe('function');
   });
 
-  it('should return undefined if the phone codes for the given wilaya code could not be found', () => {
+  it('should return null if the phone codes for the given wilaya code could not be found', () => {
     const result = getPhoneCodeForWilaya(mockData)(9);
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 
   it('should return the correct phone code for a given wilaya', () => {

--- a/tests/api/getPhoneCodesForWilaya.test.js
+++ b/tests/api/getPhoneCodesForWilaya.test.js
@@ -31,10 +31,10 @@ describe('get phone codes for a wilaya', ()=> {
     expect(typeof fn).toBe('function');
   });
 
-  it('should return undefined if the phone codes for the given wilaya code could not be found', () => {
+  it('should return null if the phone codes for the given wilaya code could not be found', () => {
     const result = getPhoneCodesForWilaya(mockData)(9);
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 
   it('should return matching phone codes array when given a wilaya code', () => {

--- a/tests/api/getWilayaByCode.test.js
+++ b/tests/api/getWilayaByCode.test.js
@@ -28,10 +28,10 @@ describe('get matching wilaya', ()=> {
     expect(typeof fn).toBe('function');
   });
 
-  it('should return undefined if the wilaya with the given mattricule is not found', () => {
+  it('should return null if the wilaya with the given mattricule is not found', () => {
     const result = getWilayaByCode(mockData)(31);
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 
   it('should return matching wilaya array', () => {

--- a/tests/api/getWilayaByDairaName.test.js
+++ b/tests/api/getWilayaByDairaName.test.js
@@ -26,22 +26,22 @@ describe('get matching wilaya', ()=> {
     expect(typeof fn).toBe('function');
   });
 
-  it('should return undefined if the wilaya with the given daira is not found', () => {
+  it('should return null if the wilaya with the given daira is not found', () => {
     const result = getWilayaByDairaName(mockData)("foo");
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 
-  it('should return undefined if there\'s no daira', () => {
+  it('should return null if there\'s no daira', () => {
     const result = getWilayaByDairaName(mockData)();
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 
-  it('should return undefined if the wilaya with the given daira is empty', () => {
+  it('should return null if the wilaya with the given daira is empty', () => {
     const result = getWilayaByDairaName(mockData)("");
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 
   it('should return matching wilaya object with arabic name', () => {

--- a/tests/api/getWilayaByPhoneCode.test.js
+++ b/tests/api/getWilayaByPhoneCode.test.js
@@ -31,10 +31,10 @@ describe('get matching wilaya', ()=> {
     expect(typeof fn).toBe('function');
   });
 
-  it('should return undefined if the wilaya with the given phoneCode is not found', () => {
+  it('should return null if the wilaya with the given phoneCode is not found', () => {
     const result = getWilayaByPhoneCode(mockData)(9);
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 
   it('should return matching wilaya array when giving phone code', () => {
@@ -57,9 +57,9 @@ describe('get matching wilaya', ()=> {
     });
   });
 
-  it('should return undefined if the given number is invalid', () => {
+  it('should return null if the given number is invalid', () => {
     const result = getWilayaByPhoneCode(mockData)('03d2345678');
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 });

--- a/tests/api/getWilayaByZipCode.test.js
+++ b/tests/api/getWilayaByZipCode.test.js
@@ -44,9 +44,9 @@ describe('get wilaya by zip code', () => {
     expect(result.mattricule).toEqual(2);
   });
 
-  it('should return undefined if the zip code doesn\'t exists', () => {
+  it('should return null if the zip code doesn\'t exists', () => {
     const result = getWilayaByZipCode(mockData)(99999);
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 });

--- a/tests/api/getZipCodesForWilaya.test.js
+++ b/tests/api/getZipCodesForWilaya.test.js
@@ -31,8 +31,8 @@ describe('Get Zip-Codes for wilaya', () => {
     expect(typeof getZipCodesForWilaya(mockData)).toBe('function');
   });
 
-  it('should return undefined if the wilaya with the given code is not found', () => {
-    expect(getZipCodesForWilaya(mockData)(289)).toBeUndefined();
+  it('should return null if the wilaya with the given code is not found', () => {
+    expect(getZipCodesForWilaya(mockData)(289)).toBeNull();
   });
 
   it('should return Zip-Codes for given wilaya code', () => {

--- a/tests/utils/projections/wilayaListProjection.test.js
+++ b/tests/utils/projections/wilayaListProjection.test.js
@@ -8,7 +8,7 @@ describe('Wilaya list projection', ()=> {
     projectWilaya = require('../../../src/utils/projections/wilayaProjection');
   });
 
-  it('return null if the wilaya parameter is undefined', () => {
+  it('should return null if the wilaya parameter is undefined', () => {
     expect(projectWilaya()).toBeNull();
     expect(projectWilaya(undefined, ['food', 'isBnin'])).toBeNull();
   });

--- a/tests/utils/projections/wilayaListProjection.test.js
+++ b/tests/utils/projections/wilayaListProjection.test.js
@@ -8,9 +8,9 @@ describe('Wilaya list projection', ()=> {
     projectWilaya = require('../../../src/utils/projections/wilayaProjection');
   });
 
-  it('if the wilaya parameter is undefined', () => {
-    expect(projectWilaya()).toBeUndefined();
-    expect(projectWilaya(undefined, ['food', 'isBnin'])).toBeUndefined();
+  it('return null if the wilaya parameter is undefined', () => {
+    expect(projectWilaya()).toBeNull();
+    expect(projectWilaya(undefined, ['food', 'isBnin'])).toBeNull();
   });
 
   describe('if no projection parameter is passed', ()=> {


### PR DESCRIPTION
# Description

A proposition to move from returning `undefined` to `null`. For more information please follow [our thread on slack](https://dzcode.slack.com/archives/C01A60X834N/p1602326905004800).

This PR adds a JEST rule forcing 100% test coverage.

# Checklist:

- [x] I checked that there's no dataset update (can be done by running `npm run update-dataset`)
- [x] `npm test` passes on my machine
- [x] `npm run lint` passes on my machine